### PR TITLE
fixed bug that caused excessive heat

### DIFF
--- a/data/usr/bin/fang-ir-control.sh
+++ b/data/usr/bin/fang-ir-control.sh
@@ -30,9 +30,9 @@ do
                 if [ $IR_ON -eq 0 ]
                 then
                        echo 0x0 > /proc/isp/filter/saturation
-                        gpio_ms1 -n 2 -m 1 -v 1 # filter movement enabled
+                        gpio_ms1 -n 2 -m 1 -v 0 # filter movement enabled
                         gpio_aud write 1 0 1    # enable ir led and latch the filter in the correct position
-                        gpio_ms1 -n 2 -m 1 -v 0 # # filter movement disabled
+                        gpio_ms1 -n 2 -m 1 -v 1 # # filter movement disabled
                         echo 0x40 > /proc/isp/filter/saturation
                         IR_ON=1
                 fi

--- a/data/usr/bin/fang-ir-control.sh
+++ b/data/usr/bin/fang-ir-control.sh
@@ -2,10 +2,11 @@
 
 echo "IR script started"
 # ir_init
-gpio_ms1 -n 2 -m 1 -v 1
-gpio_aud write 1 1 0
-gpio_aud write 0 2 1
-gpio_aud write 1 0 0
+#gpio_ms1 -n 2 -m 1 -v 1 # this causes increased current flow
+gpio_ms1 -n 2 -m 1 -v 0 # has something to do with the ir-cut/pass filter movement
+gpio_aud write 1 1 0    # pin 1 is an output and is set to low, purpose unknown
+gpio_aud write 0 2 1    # pin 2 is an input, the photoresistor
+gpio_aud write 1 0 0    # pin 0 is an output and set to low, these are the ir-leds
 
 sleep 3
 
@@ -19,8 +20,9 @@ do
         then
                 if [ $IR_ON -eq 1 ]
                 then
-                        gpio_ms1 -n 2 -m 1 -v 1
-                        gpio_aud write 1 0 0
+                        gpio_ms1 -n 2 -m 1 -v 1 # filter movement enabled
+                        gpio_aud write 1 0 0    # disable ir led and latch the filter in the correct position
+                        gpio_ms1 -n 2 -m 1 -v 0 # filter movement disabled
                         echo 0x40 > /proc/isp/filter/saturation
                         IR_ON=0
                 fi
@@ -28,8 +30,10 @@ do
                 if [ $IR_ON -eq 0 ]
                 then
                        echo 0x0 > /proc/isp/filter/saturation
-                        gpio_aud write 1 0 1
-                        gpio_ms1 -n 2 -m 1 -v 0
+                        gpio_ms1 -n 2 -m 1 -v 1 # filter movement enabled
+                        gpio_aud write 1 0 1    # enable ir led and latch the filter in the correct position
+                        gpio_ms1 -n 2 -m 1 -v 0 # # filter movement disabled
+                        echo 0x40 > /proc/isp/filter/saturation
                         IR_ON=1
                 fi
         fi


### PR DESCRIPTION
I did some measurements with a usb current meter [1] and found out, that we really should only set gpio_ms1 pin 2 to 1 when we want to change the position of the filter. How this position is changed is in fact controlled by the gpio_aud writes, maybe some latching is going on here I guess.

In daylight without an rtsp stream current is 0.29-0.32A at 4.95V.
In nightvision mode the current is 0.43-0.46A at 4.95V.

[1] http://www.banggood.com/en/KEWEISI-3V-9V-0-3A-USB-Charger-Power-Detector-Battery-Capacity-Tester-Voltage-Current-Meter-p-984613.html