### PR TITLE
enable nfs mode, can run without sdcard

### DIFF
--- a/bootstrap/S01-network.sh
+++ b/bootstrap/S01-network.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 source /etc/fang_hacks.cfg
-source /media/mmcblk0p2/data/etc/profile
 
 NETWORK_MODE=${NETWORK_MODE:-0}
 DISABLE_CLOUD=${DISABLE_CLOUD:-0}
@@ -55,7 +54,7 @@ start()
       kill_network
 
       wpa_supplicant -B -i wlan0 \
-        -c /media/mmcblk0p2/data/etc/wpa_supplicant.conf \
+        -c ${CFG_WPA} \
         -P /var/run/wpa_supplicant.pid 2>&1
       rc=$?
       if [ $rc -eq 0 ]; then
@@ -82,11 +81,11 @@ start()
         if [ $? -ne 0 ]; then
           echo "Failed to set IP $ap_addr"; return 1;
         fi
-	      hostapd -B -P /var/run/hostapd.pid /media/mmcblk0p2/data/etc/hostapd.conf 2>&1
+	      hostapd -B -P /var/run/hostapd.pid ${CFG_AP} 2>&1
         if [ $? -ne 0 ]; then
           echo "Failed to start hostapd"; return 1;
         fi
-        udhcpd -f /media//mmcblk0p2/data/etc/udhcpd.conf >>/tmp/hacks.log 2>&1 &
+        udhcpd -f ${CFG_DHCPD} >>/tmp/hacks.log 2>&1 &
         if [ $? -ne 0 ]; then
           echo "Failed to start udhcpd"; return 1;
         fi

--- a/bootstrap/S02-mount.sh
+++ b/bootstrap/S02-mount.sh
@@ -1,0 +1,19 @@
+source /etc/fang_hacks.cfg
+
+start()
+{
+  for p in $MOUNTS;do
+    mkdir -p $p
+  done
+  mount -a
+}
+
+status()
+{
+  mount
+}
+
+case $1 in start|status)
+  $1 "$@"
+  ;;
+esac

--- a/bootstrap/fang_hacks.sh
+++ b/bootstrap/fang_hacks.sh
@@ -93,6 +93,7 @@ if [ "$DISABLE_CLOUD" -eq 0 ]; then
     logmsg "Starting boa webserver..."
     # Copy to /tmp as a workaround for weird boa error (can't open boa.conf)
     cp /usr/boa/* /tmp
+    mkdir -p /tmp/cgi-bin
     /tmp/boa >/dev/null 2>&1
   fi
 
@@ -105,11 +106,16 @@ else
   logmsg "Starting boa webserver..."
   # Copy to /tmp as a workaround for weird boa error (can't open boa.conf)
   cp /usr/boa/* /tmp
+  mkdir -p /tmp/www/cgi-bin
   /tmp/boa >/dev/null 2>&1
 fi
 
 # Link cgi files again if available (/tmp is volatile)
-CGI_FILES="/media/mmcblk0p1/bootstrap/www"
+if [ -d "${HACKS_HOME}/www" ]; then
+  CGI_FILES="${HACKS_HOME}/www"
+else
+  CGI_FILES=/media/mmcblk0p1/bootstrap/www
+fi
 if [ -d "$CGI_FILES" ]; then
   for i in $CGI_FILES/*; do
     if [ ! -e "/tmp/www/cgi-bin/$(basename $i)" ]; then

--- a/bootstrap/www/action
+++ b/bootstrap/www/action
@@ -86,6 +86,8 @@ apply()
   apply_file "/media/mmcblk0p1/bootstrap/rcS" "/etc/init.d/rcS" 755
   apply_file "/media/mmcblk0p1/bootstrap/fang_hacks.sh" "/etc/fang_hacks.sh" 755
   apply_file "/media/mmcblk0p1/bootstrap/fang_hacks.cfg" "/etc/fang_hacks.cfg" 644
+  apply_file "/media/mmcblk0p1/bootstrap/S01-network.sh" "/etc/init.d/S01-network.sh" 755
+  apply_file "/media/mmcblk0p1/bootstrap/S02-mount.sh" "/etc/init.d/S02-mount.sh" 755
 
   if [ -x "/etc/fang_hacks.sh" ]; then
     echo "Running fang_hacks.sh...<br/>"

--- a/bootstrap/www/scripts
+++ b/bootstrap/www/scripts
@@ -28,8 +28,10 @@ button, input[type=submit] { background-color: #ddeaff; }
 <hr/>
 EOF
 
-SCRIPT_HOME="/media/mmcblk0p2/data/etc/scripts"
-source "/media/mmcblk0p2/data/etc/profile" >/dev/null 2>&1
+source /etc/fang_hacks.cfg
+HACKS_HOME=${HACKS_HOME:-/media/mmcblk0p2/data}
+SCRIPT_HOME="${HACKS_HOME}/etc/scripts"
+source "${HACKS_HOME}/etc/profile" >/dev/null 2>&1
 if [ -n "$F_script" ]; then
   script="${F_script##*/}"
   if [ -e "$SCRIPT_HOME/$script" ]; then
@@ -37,7 +39,7 @@ if [ -n "$F_script" ]; then
       start)
         echo "Running script '$script'...<br/>"
         echo "<pre>$($SCRIPT_HOME/$script 2>&1)</pre>"
-        ;;  
+        ;;
       disable)
         echo "Disable script '$script'...<br/>"
         chmod a-x "$SCRIPT_HOME/$script" 2>&1
@@ -80,7 +82,7 @@ else
         if [ $? -eq 0 ]; then
           if [ -n "$status" ]; then
             bgcolor="green";
-          else 
+          else
             bgcolor="orange";
           fi
         else


### PR DESCRIPTION
1. move 01-network to /etc/init.d/S01-network.sh
2. add /etc/init.d/S02-mount.sh so nfs defined in /etc/fstab can be
mounted
3. change multiple hard coded variables

nfs mode only available when cloud app is disabled.
a new config item "MOUNTS" should be defined to indicate the mount
point.
most should work properly except dropbear/sftp-server