### PR TITLE
Add driver argument to wpa invocation

### DIFF
--- a/data/etc/scripts/01-network
+++ b/data/etc/scripts/01-network
@@ -54,7 +54,7 @@ start()
       if [ ! -e "$CFG_WPA" ]; then echo "File not found: $CFG_WPA"; return 1; fi
       kill_network
 
-      wpa_supplicant -B -i wlan0 \
+      wpa_supplicant -Dwext -B -i wlan0 \
         -c /media/mmcblk0p2/data/etc/wpa_supplicant.conf \
         -P /var/run/wpa_supplicant.pid 2>&1
       rc=$?


### PR DESCRIPTION
Without this argument, the `01-network` script fails to connect to the network when in Client mode, meaning the camera can only connect to the network without the SD card present.  I'm unsure why this fails, because once the script kills `wpa_supplicant`, the network connect is dropped.

The `-Dwext` argument is passed to the initial invocation of `wpa_supplicant` on the camera (eg when there is no SD card present; when the config in `/tmp/wpa_supplicant.conf` is used).  Comparing this invocation to that within `01-network`, the `-Dwext` argument is the only difference as all arguments and configuration are identical.

Running `wpa_supplicant -h` shows that only the `wext` driver is available so that begs the question of why the argument needs to be there -- perhaps a bug or a different version between camera hardware/firmware. Mine is:
```
# /sbin/wpa_supplicant -v
wpa_supplicant v0.8.x_rtw_r7475.20130812_beta
Copyright (c) 2003-2011, Jouni Malinen <j@w1.fi> and contributors
```

Tested on MAC `34:` prefixed devices with firmware v3.0.3.56.