### PR TITLE
Unquote scan_ssid option for wpa_supplicant to work with hidden SSIDs

### DIFF
--- a/data/etc/wpa_supplicant.conf
+++ b/data/etc/wpa_supplicant.conf
@@ -8,6 +8,6 @@ network={
 	pairwise=CCMP TKIP
 	group=CCMP TKIP WEP104 WEP40
 	psk="XXXXXXXX"
-	scan_ssid="1"
+	scan_ssid=1
 	priority=2
 }


### PR DESCRIPTION
The default format of `wpa_supplicant.conf` used in `bootstrap/wpa_supplicant.conf.tmpl` and `data/etc/wpa_supplicant.conf` prevent connection to hidden SSID neworks as the `scan_ssid` option is within quotations (causing the option to be ignored).  For instance, this file will not associate with my hidden SSID network:

```
ctrl_interface=/var/run/wpa_supplicant
ctrl_interface_group=0
ap_scan=1

network={
	ssid="XXXXXXXX"
	key_mgmt=WPA-PSK
	pairwise=CCMP TKIP
	group=CCMP TKIP WEP104 WEP40
	psk="XXXXXXXX"
	scan_ssid="1"
	priority=2
}
```

but this works:

```
ctrl_interface=/var/run/wpa_supplicant
ctrl_interface_group=0
ap_scan=1

network={
	ssid="XXXXXXXX"
	key_mgmt=WPA-PSK
	pairwise=CCMP TKIP
	group=CCMP TKIP WEP104 WEP40
	psk="XXXXXXXX"
	scan_ssid=1
	priority=2
}
```

As per the man page (http://www.gsp.com/cgi-bin/man.cgi?topic=wpa_supplicant.conf#3), 
> **scan_ssid**:  SSID scan technique; 0 (default) or 1. Technique 0 scans for the SSID using a broadcast Probe Request frame while 1 uses a directed Probe Request frame. Access points that cloak themselves by not broadcasting their SSID require technique 1, but beware that this scheme can cause scanning to take longer to complete.

The quote marks in the two files mentioned above cause the value to be interpreted as the default (`0`) and thus fall back to the default behaviour, breaking connectivity with a hidden SSID network.  The correct format is shown in the examples (http://www.gsp.com/cgi-bin/man.cgi?topic=wpa_supplicant.conf#6); being the digit alone.

Separate PR will be opened shortly for the `bootstrap` submodule; see #207. 

Follows on from #205, in which the `wpa_supplicant.conf` generated using the Mi Home app to configure the camera worked, because that produced a file without quotes.
