### PR TITLE
Prevent 00-stop-cloud script from killing cloud service when cloud setting is on

### DIFF
--- a/etc/scripts/00-stop-cloud
+++ b/etc/scripts/00-stop-cloud
@@ -1,7 +1,7 @@
 #!/bin/sh
                                      
 source /etc/fang_hacks.cfg
-if [ "$DISABLE_CLOUD" -eq 0 ]; then
+if [ "$DISABLE_CLOUD" -eq 1 ]; then
 	echo "Stopping Cloud applications..."
 	pid="$(pidof test_UP)"
 	if [ $? -eq 0 ]; then


### PR DESCRIPTION
 Cloud service won't be  killed on startup when disable-cloud option is off (0)