### PR TITLE
Add RTSP watchdog script

### DIFF
--- a/etc/scripts/22-rtsp-server-watchdog
+++ b/etc/scripts/22-rtsp-server-watchdog
@@ -1,0 +1,37 @@
+#!/bin/sh
+RTSP_PIDFILE="/var/run/rtsp-server.pid"
+PIDFILE="/var/run/rtsp-server-watchdog.pid"
+
+status()
+{
+  pid="$(cat "$PIDFILE" 2>/dev/null)"
+  if [ "$pid" ]; then
+    kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
+  fi
+}
+
+start()
+{
+  LOG=/dev/null
+  echo "Starting RTSP server watchdog..."
+
+  rtsp_server_watchdog.sh $RTSP_PIDFILE >/dev/null 2>&1 &
+  echo "$!" > "$PIDFILE"
+}
+
+stop()
+{
+  pid="$(cat "$PIDFILE" 2>/dev/null)"
+  if [ "$pid" ]; then
+     kill $pid ||  rm "$PIDFILE"
+  fi
+}
+
+if [ $# -eq 0 ]; then
+  start
+else
+  case $1 in start|stop|status)
+    $1
+    ;;
+  esac
+fi

--- a/usr/bin/rtsp_server_watchdog.sh
+++ b/usr/bin/rtsp_server_watchdog.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+RTSP_PIDFILE=$1
+SLEEP=10
+echo "RSTP server watchdog started"
+
+echo "RTSP_PIDFILE=${RTSP_PIDFILE}"
+
+while true
+do
+  pid="$(cat "$RTSP_PIDFILE" 2>/dev/null)"
+  if [ "$pid" ]; then
+    kill -0 "$pid" >/dev/null && echo "RTSP server is up and running. PID: $pid" || (
+      echo "Restarting RTSP server..."
+      /media/mmcblk0p2/data/etc/scripts/20-rtsp-server start
+    )
+  fi
+
+  echo "Waiting for ${SLEEP} seconds..."
+  sleep $SLEEP
+done


### PR DESCRIPTION
I've been having a bit of an issue with my cameras when running this where they randomly crash the RTSP server.

This PR adds a watchdog script that check whether the PID described in `/var/run/rtsp-server.pid` is still alive, and if it isn't, restarts it.
It should only restart if the `stop` command was not invoked, as it will delete the `/var/run/rtsp-server.pid` file.

This check is performed every 10 seconds